### PR TITLE
티켓 조회 컨트롤러

### DIFF
--- a/src/main/java/com/ticketease/te/performance/PerformanceController.java
+++ b/src/main/java/com/ticketease/te/performance/PerformanceController.java
@@ -12,11 +12,11 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class PerformanceController {
-	private final PerformanceService performanceService;
+	private final TicketCountFacadeService ticketCountFacadeService;
 
-	@GetMapping("/api/show/{performanceId}/availableSeat")
+	@GetMapping("/api/shows/{performanceId}/availableSeat")
 	public ResponseEntity<GradeCount> countTicketByGradeFor(@RequestParam Long performanceId) {
-		GradeCount gradeCount = performanceService.countTicketByGradeForPerformance(performanceId);
+		GradeCount gradeCount = ticketCountFacadeService.countTicketByGradeForPerformance(performanceId);
 		return ResponseEntity.ok(gradeCount);
 	}
 }

--- a/src/main/java/com/ticketease/te/performance/PerformanceController.java
+++ b/src/main/java/com/ticketease/te/performance/PerformanceController.java
@@ -1,7 +1,22 @@
 package com.ticketease.te.performance;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ticketease.te.ticket.GradeCount;
+
+import lombok.RequiredArgsConstructor;
+
 @RestController
+@RequiredArgsConstructor
 public class PerformanceController {
+	private final PerformanceService performanceService;
+
+	@GetMapping("/api/show/{performanceId}/availableSeat")
+	public ResponseEntity<GradeCount> countTicketByGradeFor(@RequestParam Long performanceId) {
+		GradeCount gradeCount = performanceService.countTicketByGradeForPerformance(performanceId);
+		return ResponseEntity.ok(gradeCount);
+	}
 }

--- a/src/main/java/com/ticketease/te/performance/PerformanceDataAccessService.java
+++ b/src/main/java/com/ticketease/te/performance/PerformanceDataAccessService.java
@@ -1,0 +1,17 @@
+package com.ticketease.te.performance;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceDataAccessService implements PerformanceReader {
+	private final PerformanceRepository performanceRepository;
+
+	public Performance findBy(Long performanceId) {
+		return performanceRepository.findById(performanceId).orElseThrow(
+			() -> new IllegalArgumentException()
+		);
+	}
+}

--- a/src/main/java/com/ticketease/te/performance/PerformanceReader.java
+++ b/src/main/java/com/ticketease/te/performance/PerformanceReader.java
@@ -1,0 +1,5 @@
+package com.ticketease.te.performance;
+
+public interface PerformanceReader {
+	Performance findBy(Long performanceId);
+}

--- a/src/main/java/com/ticketease/te/performance/PerformanceService.java
+++ b/src/main/java/com/ticketease/te/performance/PerformanceService.java
@@ -10,12 +10,11 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PerformanceService {
-	private final PerformanceRepository performanceRepository;
+	private final PerformanceReader performanceReader;
 	private final TicketReader ticketReader;
 
 	public GradeCount countTicketByGradeForPerformance(Long performanceId) {
-		Performance performance = performanceRepository.findById(performanceId)
-			.orElseThrow(() -> new IllegalArgumentException("Performance not found with id: " + performanceId));
+		Performance performance = performanceReader.findBy(performanceId);
 		return ticketReader.countTicketByGradeFor(performance);
 	}
 }

--- a/src/main/java/com/ticketease/te/performance/TicketCountFacadeService.java
+++ b/src/main/java/com/ticketease/te/performance/TicketCountFacadeService.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class PerformanceService {
+public class TicketCountFacadeService {
 	private final PerformanceReader performanceReader;
 	private final TicketReader ticketReader;
 

--- a/src/test/java/com/ticketease/te/performance/board/PerformanceControllerTest.java
+++ b/src/test/java/com/ticketease/te/performance/board/PerformanceControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.ticketease.te.performance.PerformanceController;
-import com.ticketease.te.performance.PerformanceService;
+import com.ticketease.te.performance.TicketCountFacadeService;
 import com.ticketease.te.ticket.Grade;
 import com.ticketease.te.ticket.GradeCount;
 
@@ -29,7 +29,7 @@ public class PerformanceControllerTest {
 	private PerformanceController performanceController;
 
 	@Mock
-	private PerformanceService performanceService;
+	private TicketCountFacadeService ticketCountFacadeService;
 
 	@BeforeEach
 	void setUp() {
@@ -43,7 +43,7 @@ public class PerformanceControllerTest {
 		Long performanceId = 1L;
 
 		GradeCount mockGradeCount = new GradeCount(Map.of(Grade.VIP, 10, Grade.R, 5, Grade.S, 7));
-		given(performanceService.countTicketByGradeForPerformance(performanceId)).willReturn(mockGradeCount);
+		given(ticketCountFacadeService.countTicketByGradeForPerformance(performanceId)).willReturn(mockGradeCount);
 
 		String expectedJsonResponse = "{"
 			+ "\"gradeCountMap\":{"
@@ -53,7 +53,7 @@ public class PerformanceControllerTest {
 			+ "}"
 			+ "}";
 
-		mockMvc.perform(get("/api/show/{performanceId}/availableSeat", performanceId)
+		mockMvc.perform(get("/api/shows/{performanceId}/availableSeat", performanceId)
 				.param("performanceId", performanceId.toString())
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())

--- a/src/test/java/com/ticketease/te/performance/board/PerformanceControllerTest.java
+++ b/src/test/java/com/ticketease/te/performance/board/PerformanceControllerTest.java
@@ -1,0 +1,62 @@
+package com.ticketease.te.performance.board;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.ticketease.te.performance.PerformanceController;
+import com.ticketease.te.performance.PerformanceService;
+import com.ticketease.te.ticket.Grade;
+import com.ticketease.te.ticket.GradeCount;
+
+public class PerformanceControllerTest {
+
+	private MockMvc mockMvc;
+
+	@InjectMocks
+	private PerformanceController performanceController;
+
+	@Mock
+	private PerformanceService performanceService;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		mockMvc = MockMvcBuilders.standaloneSetup(performanceController).build();
+	}
+
+	@Test
+	@DisplayName("티켓 조회 성공")
+	public void countTicketByGradeFor_success() throws Exception {
+		Long performanceId = 1L;
+
+		GradeCount mockGradeCount = new GradeCount(Map.of(Grade.VIP, 10, Grade.R, 5, Grade.S, 7));
+		given(performanceService.countTicketByGradeForPerformance(performanceId)).willReturn(mockGradeCount);
+
+		String expectedJsonResponse = "{"
+			+ "\"gradeCountMap\":{"
+			+ "\"VIP\":10,"
+			+ "\"R\":5,"
+			+ "\"S\":7"
+			+ "}"
+			+ "}";
+
+		mockMvc.perform(get("/api/show/{performanceId}/availableSeat", performanceId)
+				.param("performanceId", performanceId.toString())
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().json(expectedJsonResponse));
+	}
+}

--- a/src/test/java/com/ticketease/te/performance/board/PerformanceServiceTest.java
+++ b/src/test/java/com/ticketease/te/performance/board/PerformanceServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.MockitoAnnotations;
 import com.ticketease.te.performance.Performance;
 import com.ticketease.te.performance.PerformanceDateTime;
 import com.ticketease.te.performance.PerformanceReader;
-import com.ticketease.te.performance.PerformanceService;
+import com.ticketease.te.performance.TicketCountFacadeService;
 import com.ticketease.te.ticket.Grade;
 import com.ticketease.te.ticket.GradeCount;
 import com.ticketease.te.ticket.TicketDataAccessService;
@@ -24,7 +24,7 @@ import com.ticketease.te.ticket.TicketDataAccessService;
 public class PerformanceServiceTest {
 
 	@InjectMocks
-	private PerformanceService performanceService;
+	private TicketCountFacadeService ticketCountFacadeService;
 
 	@Mock
 	private PerformanceReader performanceReader;
@@ -49,7 +49,7 @@ public class PerformanceServiceTest {
 
 		when(ticketDataAccessService.countTicketByGradeFor(mockPerformance)).thenReturn(mockGradeCount);
 
-		GradeCount result = performanceService.countTicketByGradeForPerformance(performanceId);
+		GradeCount result = ticketCountFacadeService.countTicketByGradeForPerformance(performanceId);
 
 		assertEquals(mockGradeCount, result);
 	}

--- a/src/test/java/com/ticketease/te/performance/board/PerformanceServiceTest.java
+++ b/src/test/java/com/ticketease/te/performance/board/PerformanceServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +15,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.ticketease.te.performance.Performance;
 import com.ticketease.te.performance.PerformanceDateTime;
-import com.ticketease.te.performance.PerformanceRepository;
+import com.ticketease.te.performance.PerformanceReader;
 import com.ticketease.te.performance.PerformanceService;
 import com.ticketease.te.ticket.Grade;
 import com.ticketease.te.ticket.GradeCount;
@@ -28,7 +27,7 @@ public class PerformanceServiceTest {
 	private PerformanceService performanceService;
 
 	@Mock
-	private PerformanceRepository performanceRepository;
+	private PerformanceReader performanceReader;
 
 	@Mock
 	private TicketDataAccessService ticketDataAccessService;
@@ -46,23 +45,12 @@ public class PerformanceServiceTest {
 			PerformanceDateTime.of(LocalDateTime.now(), LocalDateTime.now().plusHours(2)));
 		GradeCount mockGradeCount = GradeCount.of(Map.of(Grade.S, 10, Grade.R, 5));
 
-		when(performanceRepository.findById(performanceId)).thenReturn(Optional.of(mockPerformance));
+		when(performanceReader.findBy(performanceId)).thenReturn(mockPerformance);
 
 		when(ticketDataAccessService.countTicketByGradeFor(mockPerformance)).thenReturn(mockGradeCount);
 
 		GradeCount result = performanceService.countTicketByGradeForPerformance(performanceId);
 
 		assertEquals(mockGradeCount, result);
-	}
-
-	@Test
-	@DisplayName("존재하지 않는 공연 ID로 조회 시 예외 발생")
-	void countTicketByGradeForPerformance_failure() {
-		Long nonExistentPerformanceId = 999L;
-
-		when(performanceRepository.findById(nonExistentPerformanceId)).thenReturn(Optional.empty());
-
-		assertThrows(IllegalArgumentException.class,
-			() -> performanceService.countTicketByGradeForPerformance(nonExistentPerformanceId));
 	}
 }


### PR DESCRIPTION
# 목표
- [x] 티켓 조회 컨트롤러
- [x] 조회 컨트롤러 테스트 

# 목표가 아닌 것
- 예외 처리 코드 (이후 PR 에서 예외 처리 코드 생성)

# 고려해야 할 것
- PerformanceService 가 TicketReader 에 의존 하고 있는 데 해당 의존을 없애줘야 할 지 고민입니다.
- 의존을 없애기 위한 방법 
1. 조회 관련 서비스를 생성 해서 해당 서비스에서 의존 처리
2.  Api response 스팩 변경 (공연의 모든 티켓 조회 -> 개별 티켓 조회)

대안 별 단점
1 번 - 서비스가 하나 더 생성 되서 프로젝트 복잡도가 상승합니다.
2 번 - Api 호출 횟수 증가 
