### PR TITLE
공연 예약 락 범위 축소

### DIFF
--- a/src/main/java/com/ticketease/te/Purchase/Lockable.java
+++ b/src/main/java/com/ticketease/te/Purchase/Lockable.java
@@ -1,0 +1,6 @@
+package com.ticketease.te.Purchase;
+
+@FunctionalInterface
+public interface Lockable {
+	void lock(Long ticketId, Runnable runnable);
+}

--- a/src/main/java/com/ticketease/te/Purchase/PurchaseController.java
+++ b/src/main/java/com/ticketease/te/Purchase/PurchaseController.java
@@ -2,6 +2,7 @@ package com.ticketease.te.Purchase;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ public class PurchaseController {
 	private final PurchaseTicketLock purchaseTicketLock;
 
 	@PostMapping("/api/tickets/ticketReserve")
-	public ResponseEntity<String> reserveTicket(PurchaseRequest purchaseRequest) {
+	public ResponseEntity<String> reserveTicket(@RequestBody PurchaseRequest purchaseRequest) {
 		purchaseTicketLock.purchaseInOrder(
 			purchaseRequest.nickName(),
 			purchaseRequest.ticketId(),

--- a/src/main/java/com/ticketease/te/Purchase/PurchaseController.java
+++ b/src/main/java/com/ticketease/te/Purchase/PurchaseController.java
@@ -2,7 +2,6 @@ package com.ticketease.te.Purchase;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -13,7 +12,7 @@ public class PurchaseController {
 	private final PurchaseTicketLock purchaseTicketLock;
 
 	@PostMapping("/api/tickets/ticketReserve")
-	public ResponseEntity<String> reserveTicket(@RequestBody PurchaseRequest purchaseRequest) {
+	public ResponseEntity<String> reserveTicket(PurchaseRequest purchaseRequest) {
 		purchaseTicketLock.purchaseInOrder(
 			purchaseRequest.nickName(),
 			purchaseRequest.ticketId(),

--- a/src/main/java/com/ticketease/te/Purchase/PurchaseLock.java
+++ b/src/main/java/com/ticketease/te/Purchase/PurchaseLock.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PurchaseLock implements Lockable {
-	private final ConcurrentHashMap<Long, ReentrantLock> lockMap = new ConcurrentHashMap<>();
-	private final ConcurrentHashMap<Long, Long> timestampMap = new ConcurrentHashMap<>();
+	private final Map<Long, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+	private final Map<Long, Long> timestampMap = new ConcurrentHashMap<>();
 	private final ScheduledExecutorService ticketLockChecker = Executors.newScheduledThreadPool(1);
 
 	private PurchaseLock() {

--- a/src/main/java/com/ticketease/te/Purchase/PurchaseLock.java
+++ b/src/main/java/com/ticketease/te/Purchase/PurchaseLock.java
@@ -1,0 +1,45 @@
+package com.ticketease.te.Purchase;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PurchaseLock implements Lockable {
+	private final ConcurrentHashMap<Long, ReentrantLock> lockMap = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<Long, Long> timestampMap = new ConcurrentHashMap<>();
+	private final ScheduledExecutorService ticketLockChecker = Executors.newScheduledThreadPool(1);
+
+	private PurchaseLock() {
+		ticketLockChecker.scheduleAtFixedRate(this::cleanUp, 0, 6, TimeUnit.HOURS);
+	}
+
+	public void lock(Long ticketId, Runnable runnable) {
+		ReentrantLock lock = lockMap.computeIfAbsent(ticketId, k -> new ReentrantLock(true));
+		timestampMap.put(ticketId, System.currentTimeMillis());
+		lock.lock();
+		try {
+			runnable.run();
+		} finally {
+			lock.unlock();
+			timestampMap.put(ticketId, System.currentTimeMillis());
+		}
+	}
+
+	private void cleanUp() {
+		long threshold = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(6);
+		for (Long ticketId : timestampMap.keySet()) {
+			if (timestampMap.get(ticketId) < threshold) {
+				ReentrantLock lock = lockMap.get(ticketId);
+				if (lock != null && !lock.isLocked()) {
+					lockMap.remove(ticketId);
+					timestampMap.remove(ticketId);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/ticketease/te/Purchase/PurchaseTicketLock.java
+++ b/src/main/java/com/ticketease/te/Purchase/PurchaseTicketLock.java
@@ -1,7 +1,5 @@
 package com.ticketease.te.Purchase;
 
-import java.util.concurrent.locks.ReentrantLock;
-
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -9,16 +7,11 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class PurchaseTicketLock {
-	private ReentrantLock lock = new ReentrantLock(true);
+	private final Lockable lock;
 	private final PurchaseFacadeService purchaseFacadeService;
 
 	public void purchaseInOrder(final String nickName, final Long ticketId,
 		final Integer requestSeatCount) {
-		lock.lock();
-		try {
-			purchaseFacadeService.purchaseTicket(nickName, ticketId, requestSeatCount);
-		} finally {
-			lock.unlock();
-		}
+		lock.lock(ticketId, () -> purchaseFacadeService.purchaseTicket(nickName, ticketId, requestSeatCount));
 	}
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,3 +15,4 @@ spring:
     hibernate:
       # create 안쓰려면 springboot 실행 이전에 github action 원격지 linux 컨테이너에서 셸스크립트로 도커 컨테이너에 설치된 MySQL에 SQL을 실행시켜야함. 청천님의 슈퍼세이브 필요
       ddl-auto: create
+    open-in-view: false


### PR DESCRIPTION
# 목표로 한 것
- 공연 결제 로직 락 범위 축소

# 고려 한 것
- 락 범위 축소를 위해 ConcurrentHashMap 도입
- ConcurrentHashMap 에서 ticketId 가 계속 쌓이는 현상 방지 위해 6시간 동안 사용되지 않는 티켓 제거
- Lockable 인터페이스를 통해 함수형 프로그래밍
- OSIV false 설정